### PR TITLE
Improve default value for WeasyTemplateResponse.get_base_url()

### DIFF
--- a/django_weasyprint/views.py
+++ b/django_weasyprint/views.py
@@ -32,12 +32,11 @@ class WeasyTemplateResponse(TemplateResponse):
 
             - `settings.WEASYPRINT_BASEURL`
             - `settings.STATIC_URL`
-            - `settings.MEDIA_URL`
             - root path of the URL used in the request.
 
         :return:
         """
-        for attr in ['WEASYPRINT_BASEURL', 'STATIC_URL', 'MEDIA_URL']:
+        for attr in ['WEASYPRINT_BASEURL', 'STATIC_URL']:
             try:
                 return getattr(settings, attr)
             except AttributeError:

--- a/django_weasyprint/views.py
+++ b/django_weasyprint/views.py
@@ -28,15 +28,21 @@ class WeasyTemplateResponse(TemplateResponse):
 
     def get_base_url(self):
         """
-        Determine base URL to fetch CSS files from `WEASYPRINT_BASEURL` or
-        fall back to using the root path of the URL used in the request.
+        Determine base URL to fetch CSS files from. First one defined is used:
+
+            - `settings.WEASYPRINT_BASEURL`
+            - `settings.STATIC_URL`
+            - `settings.MEDIA_URL`
+            - root path of the URL used in the request.
 
         :return:
         """
-        return getattr(
-            settings, 'WEASYPRINT_BASEURL',
-            self._request.build_absolute_uri('/')
-        )
+        for attr in ['WEASYPRINT_BASEURL', 'STATIC_URL', 'MEDIA_URL']:
+            try:
+                return getattr(settings, attr)
+            except AttributeError:
+                pass
+        return self._request.build_absolute_uri('/')
 
     def get_css(self, base_url):
         tmp = []


### PR DESCRIPTION
Tries to fallback to Django’s settings first.