### PR TITLE
Fix reference to urlparse in utils.py

### DIFF
--- a/django_weasyprint/utils.py
+++ b/django_weasyprint/utils.py
@@ -19,7 +19,7 @@ def django_url_fetcher(url):
     # load file:// paths directly from disk
     if url.startswith('file:'):
         mime_type, encoding = mimetypes.guess_type(url)
-        url_path = parse.urlparse(url).path
+        url_path = urlparse(url).path
         data = {
             'mime_type': mime_type,
             'encoding': encoding,


### PR DESCRIPTION
Correct reference of to urlparse to prevent this error:
django_weasyprint/utils.py", line 22, in django_url_fetcher
    url_path = parse.urlparse(url).path
NameError: name 'parse' is not defined