### PR TITLE
Add font_config to handle @font-config rules

### DIFF
--- a/django_weasyprint/views.py
+++ b/django_weasyprint/views.py
@@ -55,7 +55,9 @@ class WeasyTemplateResponse(TemplateResponse):
         for value in self._stylesheets:
             #TODO test with missing or invalid css
             css = weasyprint.CSS(value, base_url=base_url,
-                                 url_fetcher=url_fetcher)
+                                 url_fetcher=url_fetcher,
+                                 font_config=weasyprint.fonts
+                                 .FontConfiguration())
             if css:
                 tmp.append(css)
         return tmp


### PR DESCRIPTION
An additional argument called font_config must be provided to handle 
@font-config rules. The same fonts.FontConfiguration object must be 
used for different CSS objects applied to the same document.

https://weasyprint.readthedocs.io/en/latest/api.html#weasyprint.CSS