### PR TITLE
Fix location of CONTENT_TYPE_PNG in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,8 @@ Example
     from django.conf import settings
     from django.views.generic import DetailView
 
-    from django_weasyprint import CONTENT_TYPE_PNG, WeasyTemplateResponseMixin
+    from django_weasyprint import WeasyTemplateResponseMixin
+    from django_weasyprint.views import CONTENT_TYPE_PNG
 
 
     class MyModelView(DetailView):


### PR DESCRIPTION
Hey, there is a typo in README

As an idea `CONTENT_TYPE_PNG` import can be added `__init__.py`, not sure is it better