### PR TITLE
Support WeasyPrint v59.0

### DIFF
--- a/django_weasyprint/views.py
+++ b/django_weasyprint/views.py
@@ -80,7 +80,7 @@ class WeasyTemplateResponse(TemplateResponse):
             url_fetcher=url_fetcher,
         )
         return html.render(
-            self.get_css(base_url, url_fetcher, font_config),
+            stylesheets=self.get_css(base_url, url_fetcher, font_config),
             font_config=font_config,
         )
 


### PR DESCRIPTION
The signature of some functions has been changed in WeasyPrint v59.0. Using a named `stylesheets` argument in `HTML.render()` works both with previous and upcoming versions of WeasyPrint.

([WeasyPrint v59.0b1](https://github.com/Kozea/WeasyPrint/releases/tag/v59.0b1) has been released today, the stable v59.0 should follow in ~2 weeks.)

(And thanks a lot for maintaining django-weasyprint!)