### PR TITLE
Update test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       USING_COVERAGE: "3.11"
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,20 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [tox]
-envlist = py{38,39,310,311}-dj{32,40,41,42}
+envlist =
+    py{38,39,310,311,312}-dj{32,42}
+    py{310,311,312}-dj{50}
 
 [testenv]
 commands = python -m unittest discover
 deps =
     coverage[toml]
     dj32: django~=3.2
-    dj40: django~=4.0
-    dj41: django~=4.1
     dj42: django~=4.2
+    dj50: django~=5.0
 
 [testenv:py311-dj42]
 # update USING_COVERAGE in GitHub action when changing Python with coverage


### PR DESCRIPTION
Add support for Python 3.12 and Django 5.0 to the test matrix and remove Django 4.0 and 4.1.