### PR TITLE
Make it possible to set WeasyPrint options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,8 @@ Example
     class DownloadView(WeasyTemplateResponseMixin, MyDetailView):
         # suggested filename (is required for attachment/download!)
         pdf_filename = 'foo.pdf'
+        # set PDF variant to pdf/ua-1
+        pdf_options = {'pdf_variant': 'pdf/ua-1'}
 
     class DynamicNameView(WeasyTemplateResponseMixin, MyDetailView):
         # dynamically generate filename

--- a/django_weasyprint/tests/__init__.py
+++ b/django_weasyprint/tests/__init__.py
@@ -49,8 +49,15 @@ class PDFView(WeasyTemplateView):
     template_name = 'example.html'
 
 
+class PDFOptionsView(WeasyTemplateView):
+    template_name = 'example.html'
+    pdf_stylesheets = [static('css/print.css')]
+    pdf_options = {'pdf_version': '1.6'}
+
+
 urlpatterns = [
     path('html/', BaseView.as_view()),
     path('pdf/', PDFView.as_view()),
     path('pdf/download/', PDFDownloadView.as_view()),
+    path('pdf/options/', PDFOptionsView.as_view()),
 ]

--- a/django_weasyprint/tests/test_views.py
+++ b/django_weasyprint/tests/test_views.py
@@ -41,3 +41,16 @@ class WeasyTemplateViewTestCase(SimpleTestCase):
         self.assertEqual(response['content-type'], 'application/pdf')
         self.assertFalse(response.has_header('content-disposition'))
         self.assertEqual(response.content[:4], b'%PDF')
+
+    @mock.patch('weasyprint.open', new_callable=lambda: mock.mock_open(read_data=b''))
+    def test_get_pdf_options(self, mock_open):
+        response = self.client.get('/pdf/options/')
+        self.assertEqual(response.status_code, 200)
+
+        # additional css from pdf_stylesheets attribute
+        mock_open.assert_called_once_with('/static/css/print.css', 'rb')
+
+        self.assertTrue(response.has_header('content-type'))
+        self.assertEqual(response['content-type'], 'application/pdf')
+        self.assertFalse(response.has_header('content-disposition'))
+        self.assertEqual(response.content[:8], b'%PDF-1.6')

--- a/django_weasyprint/views.py
+++ b/django_weasyprint/views.py
@@ -7,7 +7,7 @@ from django_weasyprint.utils import django_url_fetcher
 
 
 class WeasyTemplateResponse(TemplateResponse):
-    def __init__(self, filename=None, stylesheets=None, attachment=True,
+    def __init__(self, filename=None, stylesheets=None, attachment=True, options=None,
                  *args, **kwargs):
         """
         An HTTP response class with PDF or PNG document as content.
@@ -16,8 +16,10 @@ class WeasyTemplateResponse(TemplateResponse):
         :param attachment: set `Content-Disposition` 'attachment', a `filename`
             must be given if `True` (default: `True`)
         :param stylesheets: list of additional stylesheets
+        :param options: dictionary of options passed to WeasyPrint
         """
         self._stylesheets = stylesheets or []
+        self._options = options.copy() if options else {}
         super().__init__(*args, **kwargs)
         if filename:
             display = 'attachment' if attachment else 'inline'
@@ -79,9 +81,15 @@ class WeasyTemplateResponse(TemplateResponse):
             base_url=base_url,
             url_fetcher=url_fetcher,
         )
+
+        self._options.setdefault(
+            'stylesheets',
+            self.get_css(base_url, url_fetcher, font_config),
+        )
+
         return html.render(
-            stylesheets=self.get_css(base_url, url_fetcher, font_config),
             font_config=font_config,
+            **self._options,
         )
 
     @property
@@ -90,7 +98,7 @@ class WeasyTemplateResponse(TemplateResponse):
         Returns rendered PDF pages.
         """
         document = self.get_document()
-        return document.write_pdf()
+        return document.write_pdf(**self._options)
 
 
 class WeasyTemplateResponseMixin(TemplateResponseMixin):
@@ -102,6 +110,7 @@ class WeasyTemplateResponseMixin(TemplateResponseMixin):
     pdf_filename = None
     pdf_attachment = True
     pdf_stylesheets = []
+    pdf_options = {}
 
     def get_pdf_filename(self):
         """
@@ -122,6 +131,12 @@ class WeasyTemplateResponseMixin(TemplateResponseMixin):
         """
         return self.pdf_stylesheets
 
+    def get_pdf_options(self):
+        """
+        Returns dictionary of WeasyPrint options.
+        """
+        return self.pdf_options
+
     def render_to_response(self, context, **response_kwargs):
         """
         Renders PDF document and prepares response by calling on
@@ -134,6 +149,7 @@ class WeasyTemplateResponseMixin(TemplateResponseMixin):
             'attachment': self.pdf_attachment,
             'filename': self.get_pdf_filename(),
             'stylesheets': self.get_pdf_stylesheets(),
+            'options': self.get_pdf_options(),
         })
         return super().render_to_response(
             context, **response_kwargs


### PR DESCRIPTION
WeasyPrints can be given an options dict in the `render` and `write_pdf` methods. This PR makes it possible to do that with django-weasyprin by setting the `pdf_options` attribute on the view class or by implementing the `get_pdf_options` method.