### PR TITLE
Fix pre-commit / ruff errors

### DIFF
--- a/django_weasyprint/__init__.py
+++ b/django_weasyprint/__init__.py
@@ -1,1 +1,8 @@
-from .views import WeasyTemplateResponseMixin, WeasyTemplateView, WeasyTemplateResponse
+from .views import WeasyTemplateResponse, WeasyTemplateResponseMixin, WeasyTemplateView
+
+
+__all__ = [
+    'WeasyTemplateResponse',
+    'WeasyTemplateResponseMixin',
+    'WeasyTemplateView',
+]

--- a/django_weasyprint/tests/__init__.py
+++ b/django_weasyprint/tests/__init__.py
@@ -10,6 +10,7 @@ from django.views.generic import TemplateView
 
 from django_weasyprint import WeasyTemplateResponseMixin, WeasyTemplateView
 
+
 logging.basicConfig(level=logging.DEBUG)
 
 

--- a/django_weasyprint/utils.py
+++ b/django_weasyprint/utils.py
@@ -61,7 +61,7 @@ def django_url_fetcher(url, *args, **kwargs):
             log.debug('Static file finder returned: %s', absolute_path)
             if absolute_path:
                 log.debug('Loading static file: %s', absolute_path)
-                data['file_obj'] = open(absolute_path, 'rb')
+                data['file_obj'] = open(absolute_path, 'rb')  # noqa: PTH123
                 data['redirected_url'] = 'file://' + absolute_path
                 return data
 

--- a/django_weasyprint/views.py
+++ b/django_weasyprint/views.py
@@ -1,4 +1,5 @@
 import weasyprint
+
 from django.conf import settings
 from django.template.response import TemplateResponse
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View


### PR DESCRIPTION
I saw that the repository wasn't clean with regards to pre-commit / ruff. This PR fixes all the ruff errors.

I decided to silence the PTH123 error because Django returns strings and it doesn't make a lot of sense to me to convert the string to a Path object for a single `open` call just to make ruff happy.

It might also be a good idea to add https://pre-commit.ci/ to the repository to have pre-commit run in CI.
