### PR TITLE
Update weasyprint docs url in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Install and update using `pip`_:
 
 `WeasyPrint`_ is automatically installed as a dependency of this package.
 If you run into any problems be sure to check their `install instructions
-<https://weasyprint.readthedocs.io/en/latest/install.html>`_ for help!
+<https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation>`_ for help!
 
 .. tip::
 


### PR DESCRIPTION
Old link not work: https://weasyprint.readthedocs.io/en/latest/install.html
The moved docs into new page (i guess). New correct link is: https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation