### PR TITLE
Feat/urlfetcher class

### DIFF
--- a/src/django_weasyprint/utils.py
+++ b/src/django_weasyprint/utils.py
@@ -11,7 +11,8 @@ from django.contrib.staticfiles.finders import find
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.files.storage import default_storage
 from django.urls import get_script_prefix
-
+from weasyprint import URLFetcher
+from weasyprint.urls import URLFetcherResponse
 
 log = logging.getLogger(__name__)
 
@@ -20,6 +21,50 @@ log = logging.getLogger(__name__)
 def get_reversed_hashed_files():
     return {v: k for k, v in staticfiles_storage.hashed_files.items()}
 
+class DjangoUrlFetcher(URLFetcher):
+    def fetch(self, url, headers=None):
+        if url.startswith("file:"):
+            log.debug("Attempt to fetch from %s", url)
+            mime_type, _ = mimetypes.guess_type(url)
+            url_path = urlparse(url).path
+            default_media_url = settings.MEDIA_URL in ("", get_script_prefix())
+            if not default_media_url and url_path.startswith(settings.MEDIA_URL):
+                log.debug('URL contains MEDIA_URL (%s)', settings.MEDIA_URL)
+                cleaned_media_root = str(settings.MEDIA_ROOT)
+                if not cleaned_media_root.endswith("/"):
+                    cleaned_media_root += "/"
+                absolute_path = url_path.replace(
+                    settings.MEDIA_URL, cleaned_media_root, 1
+                )
+                log.debug("Cleaned path: %s", absolute_path)
+                body = default_storage.open(absolute_path, "rb")
+                redirected_url = "file://" + absolute_path
+                return URLFetcherResponse(
+                    redirected_url, body, {"Content-Type": mime_type}
+                )
+
+            # path looks like a static file based on configured STATIC_URL
+            elif settings.STATIC_URL and url_path.startswith(settings.STATIC_URL):
+                log.debug("URL contains STATIC_URL (%s)", settings.STATIC_URL)
+                # strip the STATIC_URL prefix to get the relative filesystem path
+                relative_path = url_path.replace(settings.STATIC_URL, "", 1)
+                # detect hashed files storage and get path with un-hashed filename
+                if not settings.DEBUG and hasattr(staticfiles_storage, "hashed_files"):
+                    log.debug("Hashed static files storage detected")
+                    relative_path = get_reversed_hashed_files()[relative_path]
+                # find the absolute path using the static file finders
+                absolute_path = find(relative_path)
+                if absolute_path:
+                    log.debug("Loading static file: %s", absolute_path)
+                    body = open(absolute_path, "rb")
+                    redirected_url = "file://" + absolute_path
+                    return URLFetcherResponse(
+                        redirected_url, body, {"Content-Type": mime_type}
+                    )
+        # Fall back to weasyprint default fetcher for http/s: and file: paths
+        # that did not match MEDIA_URL or STATIC_URL.
+        log.debug('Forwarding to weasyprint.default_url_fetcher: %s', url)
+        return super().fetch(url, headers)
 
 def django_url_fetcher(url, *args, **kwargs):
     # attempt to load file:// paths to Django MEDIA or STATIC files directly from disk

--- a/src/django_weasyprint/utils.py
+++ b/src/django_weasyprint/utils.py
@@ -53,8 +53,10 @@ class DjangoUrlFetcher(URLFetcher):
                 if not settings.DEBUG and hasattr(staticfiles_storage, 'hashed_files'):
                     log.debug('Hashed static files storage detected')
                     relative_path = get_reversed_hashed_files()[relative_path]
+                log.debug('Cleaned path: %s', relative_path)
                 # find the absolute path using the static file finders
                 absolute_path = find(relative_path)
+                log.debug('Static file finder returned: %s', absolute_path)
                 if absolute_path:
                     log.debug('Loading static file: %s', absolute_path)
                     body = open(absolute_path, 'rb')  # noqa: PTH123
@@ -64,7 +66,7 @@ class DjangoUrlFetcher(URLFetcher):
                     )
         # Fall back to weasyprint default fetcher for http/s: and file: paths
         # that did not match MEDIA_URL or STATIC_URL.
-        log.debug('Forwarding to weasyprint.default_url_fetcher: %s', url)
+        log.debug('Forwarding to weasyprint.URLFetcher: %s', url)
         return super().fetch(url, headers)
 
 def django_url_fetcher(url, *args, **kwargs):

--- a/src/django_weasyprint/utils.py
+++ b/src/django_weasyprint/utils.py
@@ -5,14 +5,15 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import weasyprint
+from weasyprint import URLFetcher
+from weasyprint.urls import URLFetcherResponse
 
 from django.conf import settings
 from django.contrib.staticfiles.finders import find
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.files.storage import default_storage
 from django.urls import get_script_prefix
-from weasyprint import URLFetcher
-from weasyprint.urls import URLFetcherResponse
+
 
 log = logging.getLogger(__name__)
 
@@ -23,43 +24,43 @@ def get_reversed_hashed_files():
 
 class DjangoUrlFetcher(URLFetcher):
     def fetch(self, url, headers=None):
-        if url.startswith("file:"):
-            log.debug("Attempt to fetch from %s", url)
+        if url.startswith('file:'):
+            log.debug('Attempt to fetch from %s', url)
             mime_type, _ = mimetypes.guess_type(url)
             url_path = urlparse(url).path
-            default_media_url = settings.MEDIA_URL in ("", get_script_prefix())
+            default_media_url = settings.MEDIA_URL in ('', get_script_prefix())
             if not default_media_url and url_path.startswith(settings.MEDIA_URL):
                 log.debug('URL contains MEDIA_URL (%s)', settings.MEDIA_URL)
                 cleaned_media_root = str(settings.MEDIA_ROOT)
-                if not cleaned_media_root.endswith("/"):
-                    cleaned_media_root += "/"
+                if not cleaned_media_root.endswith('/'):
+                    cleaned_media_root += '/'
                 absolute_path = url_path.replace(
                     settings.MEDIA_URL, cleaned_media_root, 1
                 )
-                log.debug("Cleaned path: %s", absolute_path)
-                body = default_storage.open(absolute_path, "rb")
-                redirected_url = "file://" + absolute_path
+                log.debug('Cleaned path: %s', absolute_path)
+                body = default_storage.open(absolute_path, 'rb')
+                redirected_url = 'file://' + absolute_path
                 return URLFetcherResponse(
-                    redirected_url, body, {"Content-Type": mime_type}
+                    redirected_url, body, {'Content-Type': mime_type}
                 )
 
             # path looks like a static file based on configured STATIC_URL
             elif settings.STATIC_URL and url_path.startswith(settings.STATIC_URL):
-                log.debug("URL contains STATIC_URL (%s)", settings.STATIC_URL)
+                log.debug('URL contains STATIC_URL (%s)', settings.STATIC_URL)
                 # strip the STATIC_URL prefix to get the relative filesystem path
-                relative_path = url_path.replace(settings.STATIC_URL, "", 1)
+                relative_path = url_path.replace(settings.STATIC_URL, '', 1)
                 # detect hashed files storage and get path with un-hashed filename
-                if not settings.DEBUG and hasattr(staticfiles_storage, "hashed_files"):
-                    log.debug("Hashed static files storage detected")
+                if not settings.DEBUG and hasattr(staticfiles_storage, 'hashed_files'):
+                    log.debug('Hashed static files storage detected')
                     relative_path = get_reversed_hashed_files()[relative_path]
                 # find the absolute path using the static file finders
                 absolute_path = find(relative_path)
                 if absolute_path:
-                    log.debug("Loading static file: %s", absolute_path)
-                    body = open(absolute_path, "rb")
-                    redirected_url = "file://" + absolute_path
+                    log.debug('Loading static file: %s', absolute_path)
+                    body = open(absolute_path, 'rb')  # noqa: PTH123
+                    redirected_url = 'file://' + absolute_path
                     return URLFetcherResponse(
-                        redirected_url, body, {"Content-Type": mime_type}
+                        redirected_url, body, {'Content-Type': mime_type}
                     )
         # Fall back to weasyprint default fetcher for http/s: and file: paths
         # that did not match MEDIA_URL or STATIC_URL.

--- a/tests/test_djangourlfetcher.py
+++ b/tests/test_djangourlfetcher.py
@@ -12,22 +12,22 @@ class URLFetcherTest(SimpleTestCase):
     def setUp(self):
         get_reversed_hashed_files.cache_clear()
 
-    # def test_default(self):
+    def test_default(self):
         # MEDIA_URL='' and STATIC_URL=None, all requests passed though
-        # url = 'https://s3.amazon.test/images/image.jpg'
-        # with mock.patch('weasyprint.URLFetcher') as url_fetcher:
-        #     DjangoUrlFetcher().fetch(url)
-        # url_fetcher.assert_called_once_with(url)
-        #
-        # url = 'file:///media/image.jpg'
-        # with mock.patch('weasyprint.URLFetcher') as url_fetcher:
-        #     DjangoUrlFetcher().fetch(url)
-        # url_fetcher.assert_called_once_with(url)
+        url = 'https://s3.amazon.test/images/image.jpg'
+        with mock.patch('weasyprint.URLFetcher') as url_fetcher:
+            DjangoUrlFetcher().fetch(url)
+        url_fetcher.assert_called_once_with(url)
 
-        # url = 'file:///static/styles.css'
-        # with mock.patch('weasyprint.URLFetcher') as url_fetcher:
-        #     DjangoUrlFetcher().fetch(url)
-        # url_fetcher.assert_called_once_with(url)
+        url = 'file:///media/image.jpg'
+        with mock.patch('weasyprint.URLFetcher') as url_fetcher:
+            DjangoUrlFetcher().fetch(url)
+        url_fetcher.assert_called_once_with(url)
+
+        url = 'file:///static/styles.css'
+        with mock.patch('weasyprint.URLFetcher') as url_fetcher:
+            DjangoUrlFetcher().fetch(url)
+        url_fetcher.assert_called_once_with(url)
 
     def assert_data(self, data, file_path, mime_type):
         self.assertIsInstance(data, URLFetcherResponse)
@@ -110,16 +110,16 @@ class URLFetcherTest(SimpleTestCase):
         mock_open.assert_called_once_with('/www/static/css/styles.css', 'rb')
         self.assert_data(data, '/www/static/css/styles.css', 'text/css')
 
-    # @override_settings(STATIC_URL='/static/', STATIC_ROOT='/www/static')
-    # @mock.patch('django_weasyprint.utils.open')
-    # @mock.patch('django_weasyprint.utils.find', return_value=None)
-    # @mock.patch('weasyprint.default_url_fetcher')
-    # def test_static_file_not_found(self, mock_fetcher, mock_find, mock_open):
-    #     # request matches STATIC_URL, request handled,
-    #     # but staticfiles finder returns None
-    #     url = 'file:///static/css/missing.css'
-    #     django_url_fetcher(url)
-    #     mock_find.assert_called_once_with('css/missing.css')
-    #     mock_open.assert_not_called()
-    #     # request was forwarded to default fetcher
-    #     mock_fetcher.assert_called_once_with('file:///static/css/missing.css')
+    @override_settings(STATIC_URL='/static/', STATIC_ROOT='/www/static')
+    @mock.patch('django_weasyprint.utils.open')
+    @mock.patch('django_weasyprint.utils.find', return_value=None)
+    @mock.patch('weasyprint.URLFetcher')
+    def test_static_file_not_found(self, mock_fetcher, mock_find, mock_open):
+        # request matches STATIC_URL, request handled,
+        # but staticfiles finder returns None
+        url = 'file:///static/css/missing.css'
+        DjangoUrlFetcher().fetch(url)
+        mock_find.assert_called_once_with('css/missing.css')
+        mock_open.assert_not_called()
+        # request was forwarded to default fetcher
+        mock_fetcher.assert_called_once_with('file:///static/css/missing.css')

--- a/tests/test_djangourlfetcher.py
+++ b/tests/test_djangourlfetcher.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+from unittest import mock
+
+from weasyprint.urls import URLFetcherResponse
+
+from django.test import SimpleTestCase, override_settings
+
+from django_weasyprint.utils import DjangoUrlFetcher, get_reversed_hashed_files
+
+
+class URLFetcherTest(SimpleTestCase):
+    def setUp(self):
+        get_reversed_hashed_files.cache_clear()
+
+    # def test_default(self):
+        # MEDIA_URL='' and STATIC_URL=None, all requests passed though
+        # url = 'https://s3.amazon.test/images/image.jpg'
+        # with mock.patch('weasyprint.URLFetcher') as url_fetcher:
+        #     DjangoUrlFetcher().fetch(url)
+        # url_fetcher.assert_called_once_with(url)
+        #
+        # url = 'file:///media/image.jpg'
+        # with mock.patch('weasyprint.URLFetcher') as url_fetcher:
+        #     DjangoUrlFetcher().fetch(url)
+        # url_fetcher.assert_called_once_with(url)
+
+        # url = 'file:///static/styles.css'
+        # with mock.patch('weasyprint.URLFetcher') as url_fetcher:
+        #     DjangoUrlFetcher().fetch(url)
+        # url_fetcher.assert_called_once_with(url)
+
+    def assert_data(self, data, file_path, mime_type):
+        self.assertIsInstance(data, URLFetcherResponse)
+        self.assertEqual(data.content_type, mime_type)
+        self.assertEqual(data.url, 'file://' + file_path)
+
+    @override_settings(MEDIA_URL='/media/', MEDIA_ROOT='/www/media/')
+    @mock.patch('django_weasyprint.utils.default_storage.open')
+    @mock.patch('weasyprint.URLFetcher')
+    def test_media_with_trailing_slash(self, mock_fetcher, mock_open):
+        # request matches MEDIA_URL, request handled
+        url = 'file:///media/image.jpg'
+        data = DjangoUrlFetcher().fetch(url)
+        mock_fetcher.assert_not_called()
+        mock_open.assert_called_once_with('/www/media/image.jpg', 'rb')
+        self.assert_data(data, '/www/media/image.jpg', 'image/jpeg')
+
+    @override_settings(MEDIA_URL='/media/', MEDIA_ROOT=Path('/www/media'))
+    @mock.patch('django_weasyprint.utils.default_storage.open')
+    @mock.patch('weasyprint.URLFetcher')
+    def test_media_root_pathlib_no_slash(self, mock_fetcher, mock_open):
+        # request matches MEDIA_URL, request handled
+        url = 'file:///media/image.jpg'
+        data = DjangoUrlFetcher().fetch(url)
+        mock_fetcher.assert_not_called()
+        mock_open.assert_called_once_with('/www/media/image.jpg', 'rb')
+        self.assert_data(data, '/www/media/image.jpg', 'image/jpeg')
+    #
+    @override_settings(STATIC_URL='/static/', STATIC_ROOT='/www/static')
+    @mock.patch('django_weasyprint.utils.open')
+    @mock.patch('django_weasyprint.utils.find', return_value='/www/static/css/styles.css')
+    @mock.patch('weasyprint.URLFetcher')
+    def test_static(self, mock_fetcher, mock_find, mock_open):
+        # request matches STATIC_URL, request handled
+        url = 'file:///static/css/styles.css'
+        data = DjangoUrlFetcher().fetch(url)
+        mock_fetcher.assert_not_called()
+        mock_find.assert_called_once_with('css/styles.css')
+        mock_open.assert_called_once_with('/www/static/css/styles.css', 'rb')
+        self.assert_data(data, '/www/static/css/styles.css', 'text/css')
+    #
+    # @override_settings(
+    #     STATIC_URL='/static/',
+    #     STATIC_ROOT='/www/static',
+    #     STATICFILES_STORAGE='django.contrib.staticfiles.storage.ManifestStaticFilesStorage',  # noqa
+    #     STORAGES={
+    #         'staticfiles': {
+    #             'BACKEND': 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage',  # noqa
+    #         },
+    #     }
+    # )
+    # @mock.patch(
+    #     'django_weasyprint.utils.staticfiles_storage.hashed_files',
+    #     new_callable=mock.PropertyMock(return_value={
+    #         'css/styles.css': 'css/styles.60b250d16a6a.css',
+    #     }),
+    # )
+    # @mock.patch('django_weasyprint.utils.open')
+    # @mock.patch('django_weasyprint.utils.find',
+    # return_value='/www/static/css/styles.css')
+    # @mock.patch('weasyprint.default_url_fetcher')
+    # def test_manifest_static(self, mock_fetcher, mock_find, mock_open, hashed_files):
+    #     # request matches STATIC_URL, request handled
+    #     url = 'file:///static/css/styles.60b250d16a6a.css'
+    #     data = django_url_fetcher(url)
+    #     mock_fetcher.assert_not_called()
+    #     mock_find.assert_called_once_with('css/styles.css')
+    #     mock_open.assert_called_once_with('/www/static/css/styles.css', 'rb')
+    #     self.assert_data(data, '/www/static/css/styles.css', 'text/css')
+    #
+    #     mock_find.reset_mock()
+    #     mock_open.reset_mock()
+    #
+    #     # ManifestStaticFilesStorage.url() returns un-hashed URL with DEBUG=True,
+    #     # django_url_fetcher() is still able to find the file.
+    #     with override_settings(DEBUG=True):
+    #         data = django_url_fetcher('file:///static/css/styles.css')
+    #     mock_fetcher.assert_not_called()
+    #     mock_find.assert_called_once_with('css/styles.css')
+    #     mock_open.assert_called_once_with('/www/static/css/styles.css', 'rb')
+    #     self.assert_data(data, '/www/static/css/styles.css', 'text/css')
+    #
+    # @override_settings(STATIC_URL='/static/', STATIC_ROOT='/www/static')
+    # @mock.patch('django_weasyprint.utils.open')
+    # @mock.patch('django_weasyprint.utils.find', return_value=None)
+    # @mock.patch('weasyprint.default_url_fetcher')
+    # def test_static_file_not_found(self, mock_fetcher, mock_find, mock_open):
+    #     # request matches STATIC_URL, request handled,
+    #     # but staticfiles finder returns None
+    #     url = 'file:///static/css/missing.css'
+    #     django_url_fetcher(url)
+    #     mock_find.assert_called_once_with('css/missing.css')
+    #     mock_open.assert_not_called()
+    #     # request was forwarded to default fetcher
+    #     mock_fetcher.assert_called_once_with('file:///static/css/missing.css')

--- a/tests/test_djangourlfetcher.py
+++ b/tests/test_djangourlfetcher.py
@@ -68,48 +68,48 @@ class URLFetcherTest(SimpleTestCase):
         mock_find.assert_called_once_with('css/styles.css')
         mock_open.assert_called_once_with('/www/static/css/styles.css', 'rb')
         self.assert_data(data, '/www/static/css/styles.css', 'text/css')
-    #
-    # @override_settings(
-    #     STATIC_URL='/static/',
-    #     STATIC_ROOT='/www/static',
-    #     STATICFILES_STORAGE='django.contrib.staticfiles.storage.ManifestStaticFilesStorage',  # noqa
-    #     STORAGES={
-    #         'staticfiles': {
-    #             'BACKEND': 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage',  # noqa
-    #         },
-    #     }
-    # )
-    # @mock.patch(
-    #     'django_weasyprint.utils.staticfiles_storage.hashed_files',
-    #     new_callable=mock.PropertyMock(return_value={
-    #         'css/styles.css': 'css/styles.60b250d16a6a.css',
-    #     }),
-    # )
-    # @mock.patch('django_weasyprint.utils.open')
-    # @mock.patch('django_weasyprint.utils.find',
-    # return_value='/www/static/css/styles.css')
-    # @mock.patch('weasyprint.default_url_fetcher')
-    # def test_manifest_static(self, mock_fetcher, mock_find, mock_open, hashed_files):
-    #     # request matches STATIC_URL, request handled
-    #     url = 'file:///static/css/styles.60b250d16a6a.css'
-    #     data = django_url_fetcher(url)
-    #     mock_fetcher.assert_not_called()
-    #     mock_find.assert_called_once_with('css/styles.css')
-    #     mock_open.assert_called_once_with('/www/static/css/styles.css', 'rb')
-    #     self.assert_data(data, '/www/static/css/styles.css', 'text/css')
-    #
-    #     mock_find.reset_mock()
-    #     mock_open.reset_mock()
-    #
-    #     # ManifestStaticFilesStorage.url() returns un-hashed URL with DEBUG=True,
-    #     # django_url_fetcher() is still able to find the file.
-    #     with override_settings(DEBUG=True):
-    #         data = django_url_fetcher('file:///static/css/styles.css')
-    #     mock_fetcher.assert_not_called()
-    #     mock_find.assert_called_once_with('css/styles.css')
-    #     mock_open.assert_called_once_with('/www/static/css/styles.css', 'rb')
-    #     self.assert_data(data, '/www/static/css/styles.css', 'text/css')
-    #
+
+    @override_settings(
+        STATIC_URL='/static/',
+        STATIC_ROOT='/www/static',
+        STATICFILES_STORAGE='django.contrib.staticfiles.storage.ManifestStaticFilesStorage',  # noqa
+        STORAGES={
+            'staticfiles': {
+                'BACKEND': 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage',  # noqa
+            },
+        }
+    )
+    @mock.patch(
+        'django_weasyprint.utils.staticfiles_storage.hashed_files',
+        new_callable=mock.PropertyMock(return_value={
+            'css/styles.css': 'css/styles.60b250d16a6a.css',
+        }),
+    )
+    @mock.patch('django_weasyprint.utils.open')
+    @mock.patch('django_weasyprint.utils.find',
+    return_value='/www/static/css/styles.css')
+    @mock.patch('weasyprint.URLFetcher')
+    def test_manifest_static(self, mock_fetcher, mock_find, mock_open, hashed_files):
+        # request matches STATIC_URL, request handled
+        url = 'file:///static/css/styles.60b250d16a6a.css'
+        data = DjangoUrlFetcher().fetch(url)
+        mock_fetcher.assert_not_called()
+        mock_find.assert_called_once_with('css/styles.css')
+        mock_open.assert_called_once_with('/www/static/css/styles.css', 'rb')
+        self.assert_data(data, '/www/static/css/styles.css', 'text/css')
+
+        mock_find.reset_mock()
+        mock_open.reset_mock()
+
+        # ManifestStaticFilesStorage.url() returns un-hashed URL with DEBUG=True,
+        # django_url_fetcher() is still able to find the file.
+        with override_settings(DEBUG=True):
+            data = DjangoUrlFetcher().fetch('file:///static/css/styles.css')
+        mock_fetcher.assert_not_called()
+        mock_find.assert_called_once_with('css/styles.css')
+        mock_open.assert_called_once_with('/www/static/css/styles.css', 'rb')
+        self.assert_data(data, '/www/static/css/styles.css', 'text/css')
+
     # @override_settings(STATIC_URL='/static/', STATIC_ROOT='/www/static')
     # @mock.patch('django_weasyprint.utils.open')
     # @mock.patch('django_weasyprint.utils.find', return_value=None)


### PR DESCRIPTION
Should resolve #106 . Unfortunately, the tests with missing files are not working and I'm not sure how the `django-weasyprint`wants to handle it.